### PR TITLE
Fix summary statistics for multiple highdim nodes in study.

### DIFF
--- a/grails-app/conf/ehcache.xml
+++ b/grails-app/conf/ehcache.xml
@@ -138,4 +138,9 @@
 		timeToIdleSeconds="300"
 		/>
 
+    <cache name="org.transmartproject.HighDimChartDataService"
+        maxElementsInMemory="10000"
+        timeToIdleSeconds="300"
+        />
+
 </ehcache>

--- a/grails-app/services/ChartService.groovy
+++ b/grails-app/services/ChartService.groovy
@@ -27,6 +27,11 @@ import com.recomdata.export.ExportColumn
 import com.recomdata.export.ExportRowNew
 import com.recomdata.export.ExportTableNew
 
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
+import org.transmartproject.core.dataquery.highdim.HighDimensionResource
+import org.transmartproject.core.dataquery.highdim.assayconstraints.AssayConstraint
+
 /**
  * Created by Florian Guitton <f.guitton@imperial.ac.uk> on 17/12/2014.
  */
@@ -131,10 +136,16 @@ class ChartService {
 
         def metadata = exportMetadataService.getHighDimMetaData(subsets[1]?.instance as Long, subsets[2]?.instance as Long)
         metadata.each { data ->
-            log.debug "addHighDimDataToTable: dataType = ${data.datatype}"
+            log.debug "addHighDimDataToTable: dataType = ${data.datatype.dataTypeName}"
             def rowdata = [:]
             subsets.each { k, v ->
                 if (v.instance) {
+                    def conceptDataType = highDimChartDataService.getDataTypeForConcept(concept)
+                    if (conceptDataType != data.datatype.dataTypeName) {
+                        log.debug "Concept data type (${conceptDataType}) is not the same as the data type associated with the subset (${data.datatype.dataTypeName})"
+                        return
+                    }
+
                     def assayConstraints = [
                             (AssayConstraint.PATIENT_SET_CONSTRAINT):
                                 [[result_instance_id: v.instance]],
@@ -182,7 +193,12 @@ class ChartService {
         List<Map> result = []
         def metadata = exportMetadataService.getHighDimMetaData(subsets[1]?.instance as Long, subsets[2]?.instance as Long)
         metadata.each { data ->
-            log.debug "getHighDimAnalysis: concept = ${concept}, dataType = ${data.datatype}"
+            log.debug "getHighDimAnalysis: concept = ${concept}, dataType = ${data.datatype.dataTypeName}"
+            def conceptDataType = highDimChartDataService.getDataTypeForConcept(concept)
+            if (conceptDataType != data.datatype.dataTypeName) {
+                log.debug "Concept data type (${conceptDataType}) is not the same as the data type associated with the subset (${data.datatype.dataTypeName})"
+                return
+            }
             Map<String, Map<String, Map>> barChartData = [:] // maps subsets to a map from row label to row data
             subsets.each { subset, properties ->
                 if (properties.instance) {

--- a/grails-app/services/org/transmartproject/HighDimChartDataService.groovy
+++ b/grails-app/services/org/transmartproject/HighDimChartDataService.groovy
@@ -1,5 +1,6 @@
 package org.transmartproject
 
+import grails.plugin.cache.Cacheable
 import grails.transaction.Transactional
 
 import org.transmartproject.core.dataquery.TabularResult
@@ -16,6 +17,25 @@ import com.recomdata.transmart.data.export.HighDimExportService
 class HighDimChartDataService {
 
     HighDimensionResource highDimensionResourceService
+
+    @Cacheable('org.transmartproject.HighDimChartDataService')
+    String getDataTypeForConcept(String concept_key) {
+        def constraints = []
+
+        constraints << highDimensionResourceService.createAssayConstraint(
+                [concept_key: concept_key],
+                AssayConstraint.ONTOLOGY_TERM_CONSTRAINT)
+
+        def assayMultiMap = highDimensionResourceService.
+                getSubResourcesAssayMultiMap(constraints)
+
+        def result = assayMultiMap.collect { HighDimensionDataTypeResource dataTypeResource,
+                                             Collection<Assay> assays ->
+            dataTypeResource.dataTypeName
+        }
+        assert(result.size() == 1)
+        result[0]
+    }
 
     Set<String> getSupportedDataConstraints(String dataType) {
         HighDimensionDataTypeResource typeResource =


### PR DESCRIPTION
Fix the problem with multiple highdim nodes in a
study with incompatible filter types.
Before fetching the data for the data types associated
with the selected assays, the data type is compared to
the selected concept.